### PR TITLE
Remove pycoin dependency and use ecdsa for mitm_verify

### DIFF
--- a/ckcc/utils.py
+++ b/ckcc/utils.py
@@ -1,4 +1,5 @@
 import struct
+import binascii
 from collections import namedtuple
 
 def dfu_parse(fd):
@@ -44,5 +45,44 @@ def dfu_parse(fd):
 
             yield fd.tell()
             yield elem.size
+
+# Adapted from https://github.com/petertodd/python-bitcoinlib/blob/master/bitcoin/base58.py
+def decode_xpub(s):
+    assert s[1:].startswith('pub')
+    b58_digits = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+    # Convert the string to an integer
+    n = 0
+    for c in s:
+        n *= 58
+        if c not in b58_digits:
+            raise ValueError('Character %r is not a valid base58 character' % c)
+        digit = b58_digits.index(c)
+        n += digit
+
+    # Convert the integer to bytes
+    h = '%x' % n
+    if len(h) % 2:
+        h = '0' + h
+    res = binascii.unhexlify(h.encode('utf8'))
+
+    # Add padding back.
+    pad = 0
+    for c in s[:-1]:
+        if c == b58_digits[0]: pad += 1
+        else: break
+    decoded = b'\x00' * pad + res
+
+    # Get the pubkey and chaincode
+    return decoded[-37:-4], decoded[-69:-37]
+
+def get_pubkey_string(b):
+    p = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+
+    x = int.from_bytes(b[1:], byteorder="big")
+    y = pow((x*x*x + 7) % p, (p + 1) // 4, p)
+    if (y & 1 != b[0] & 1):
+        y = p - y
+    return x.to_bytes(32, byteorder="big") + y.to_bytes(32, byteorder="big")
 
 # EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,3 @@ click>=6.7
 # required by link-layer encryption in client.py
 ecdsa>=0.13
 pyaes
-
-# optional: to verify against active MiTM attacks
-pycoin==0.80
-

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ requirements = [
 
 cli_requirements = [
     'click>=6.7',
-    'pycoin==0.80',
 ]
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Instead of using the large pycoin dependency, just use ecdsa to do the signature verification.

To facilitate this, two additional utility functions were added: `decode_xpub` and `get_pubkey_string`. `decode_xpub` decodes the base58 encoded xpub and returns the pubkey and chaincode. `get_pubkey_string` decompresses the pubkey and returns it as a string that ecdsa can use. Then the signature verification can be done using ecdsa.