### PR TITLE
Ignore and suppress 'hid_error is not implemented yet' error

### DIFF
--- a/ckcc/client.py
+++ b/ckcc/client.py
@@ -90,7 +90,7 @@ class ColdcardDevice:
 
         # check the above all worked
         err = self.dev.error()
-        if err != '':
+        if err != '' and err != 'hid_error is not implemented yet':
             raise RuntimeError('hidapi: '+err)
 
         assert self.dev.get_serial_number_string() == self.serial


### PR DESCRIPTION
This seems to be an entirely non-critical, in fact maybe even a false-error returned from `self.dev.error()`.

`ckcc list` always worked with and without this patch but no other `ckcc` command worked, all raised the `RuntimeError` below.

Without this patch:
```
$ ckcc test                                                                                                                                                                                                                                                                                                                                                                                                                   
About to resync...
Traceback (most recent call last):
  File "/mnt/tb/Downloads/ckcc-protocol/env/bin/ckcc", line 11, in <module>
    load_entry_point('ckcc-protocol', 'console_scripts', 'ckcc')()
  File "/mnt/tb/Downloads/ckcc-protocol/env/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/mnt/tb/Downloads/ckcc-protocol/env/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/mnt/tb/Downloads/ckcc-protocol/env/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/mnt/tb/Downloads/ckcc-protocol/env/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/mnt/tb/Downloads/ckcc-protocol/env/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/mnt/tb/Downloads/ckcc-protocol/ckcc/cli.py", line 153, in usb_test
    dev = ColdcardDevice(sn=force_serial)
  File "/mnt/tb/Downloads/ckcc-protocol/ckcc/client.py", line 66, in __init__
    self.resync()
  File "/mnt/tb/Downloads/ckcc-protocol/ckcc/client.py", line 95, in resync
    raise RuntimeError('hidapi: '+err)
RuntimeError: hidapi: hid_error is not implemented yet
```

With this patch:
```
$ ckcc test
WARN: hid_error_not_implemented error thrown. Suppressing.
Ping with length: 55  Okay
Ping with length: 56  Okay
Ping with length: 57  Okay
Ping with length: 58  Okay
Ping with length: 59  Okay
Ping with length: 60  Okay
Ping with length: 61  Okay
Ping with length: 62  Okay
Ping with length: 63  Okay
Ping with length: 64  Okay
Ping with length: 65  Okay
Ping with length: 1013  Okay
Ping with length: 1014  Okay
Ping with length: 1015  Okay
Ping with length: 1016  Okay
Ping with length: 1017  Okay
Ping with length: 1018  Okay
Ping with length: 1019  Okay
Ping with length: 1020  Okay
Ping with length: 1021  Okay
Ping with length: 1022  Okay
Ping with length: 1023  Okay
Ping with length: 2050  Okay
Ping with length: 2051  Okay
Ping with length: 2052  Okay
Ping with length: 2053  Okay
Ping with length: 2054  Okay
Ping with length: 2055  Okay
```
