### PR TITLE
avoided bare except

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -198,7 +198,7 @@ def real_file_upload(fd, blksize=MAX_BLK_LEN, do_upgrade=False, do_reboot=True, 
 
             magic = struct.unpack_from("<I", hdr)[0]
             #print("hdr @ 0x%x: %s" % (FW_HEADER_OFFSET, b2a_hex(hdr)))
-        except:
+        except Exception:
             magic = None
 
         if magic != FW_HEADER_MAGIC:
@@ -302,7 +302,7 @@ def get_pubkey(subpath):
 
     try:
         from pycoin.key.BIP32Node import BIP32Node
-    except:
+    except Exception:
         raise click.Abort("pycoin must be installed, not found.")
 
     dev = ColdcardDevice(sn=force_serial)

--- a/ckcc/client.py
+++ b/ckcc/client.py
@@ -164,7 +164,7 @@ class ColdcardDevice:
         except CCProtoError as e:
             if expect_errors: raise
             raise
-        except:
+        except Exception:
             #print("Corrupt response: %r" % resp)
             raise
 
@@ -346,7 +346,7 @@ class UnixSimulatorPipe:
         self.pipe = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
         try:
             self.pipe.connect(path)
-        except:
+        except Exception:
             self.close()
             raise RuntimeError("Cannot connect to simulator. Is it running?")
 
@@ -388,7 +388,8 @@ class UnixSimulatorPipe:
         self.pipe.close()
         try:
             os.unlink(self.pipe_name)
-        except: pass
+        except Exception:
+            pass
 
     def get_serial_number_string(self):
         return 'simulator'


### PR DESCRIPTION
Using a bare `except:` is not a good coding practice: it catches all exceptions inheriting from `BaseException`, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (which is not an error and should not normally be caught by user code).
```
BaseException
  - Exception
  - GeneratorExit
  - KeyboardInterrupt
  - SystemExit
```
This patch is sub-optimal because only specific exceptions should be catched... anyway, in situations where one wants to catch all “normal” exceptions, at least restrict to explicitly catch the `Exception` base class, instead of implicitly catching any BaseException.

See also: https://github.com/bitcoin-core/HWI/pull/373