### PR TITLE
extended sign_message to also sign bytes, not only string

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -403,7 +403,7 @@ def sign_message(message, path, verbose=True, just_sig=False, wrap=False, segwit
     # standard very much still in flux, see: <https://github.com/bitcoin/bitcoin/issues/10542>
 
     # not enforcing policy here on msg contents, so we can define that on product
-    message = message.encode('ascii')
+    message = message.encode('ascii') if not isinstance(message, bytes) else message
 
     ok = dev.send_recv(CCProtocolPacker.sign_message(message, path, addr_fmt), timeout=None)
     assert ok == None


### PR DESCRIPTION
Bitcoin message signing is usually used to sign an input string which, as first step, is encoded to bytes. The rest of the implementation assumes bytes, operates on bytes, ecdsa-signs bytes.

This PR proposes to skip the string encoding if bytes, instead of a string, are provided as input: this allow to "bitcoin message sign" an arbitrary byte sequence (note that arbitrary byte sequences cannot be always decoded to strings).

See also https://github.com/bitcoin-core/HWI/pull/366