### PR TITLE
Remove pycoin

### DIFF
--- a/ckcc/client.py
+++ b/ckcc/client.py
@@ -247,19 +247,6 @@ class ColdcardDevice:
         self.aes_setup(self.session_key)
 
     def mitm_verify(self, sig, expected_xpub):
-        # First try with Pycoin
-        try:
-            from pycoin.key.BIP32Node import BIP32Node
-            from pycoin.contrib.msg_signing import verify_message
-            from pycoin.encoding  import from_bytes_32
-            from base64 import b64encode
-
-            mk = BIP32Node.from_wallet_key(expected_xpub)
-            return verify_message(mk, b64encode(sig), msg_hash=from_bytes_32(self.session_key))
-        except ImportError:
-            pass
-
-        # If Pycoin is not available, do it using ecdsa
         from ecdsa import BadSignatureError, SECP256k1, VerifyingKey
         # of the returned (pubkey, chaincode) tuple, chaincode is not used
         pubkey, _ = decode_xpub(expected_xpub)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ hidapi>=0.7.99.post21
 click>=6.7
 
 # required by link-layer encryption in client.py
-ecdsa>=0.13
+ecdsa
 pyaes

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ hidapi>=0.7.99.post21
 click>=6.7
 
 # required by link-layer encryption in client.py
-ecdsa
+ecdsa>=0.17
 pyaes

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 requirements = [
     'hidapi>=0.7.99.post21',
-    'ecdsa',
+    'ecdsa>=0.17',
     'pyaes',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 requirements = [
     'hidapi>=0.7.99.post21',
-    'ecdsa>=0.13',
+    'ecdsa',
     'pyaes',
 ]
 


### PR DESCRIPTION
* pycoin snippets were not working with newest available pycoin from pypi
* as pycoin is not part of the dependecy list - it should be removed
* we are able to leverage ecdsa for all the pycoin tasks (yet must be bumped from 0.13 version where it lacks compression parameter for VerifyingKey)
