### PR TITLE
Usb ncry v2

### DIFF
--- a/ckcc/__init__.py
+++ b/ckcc/__init__.py
@@ -1,6 +1,6 @@
 # (c) Copyright 2021 by Coinkite Inc. This file is covered by license found in COPYING-CC.
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 __all__ = [ "client", "protocol", "constants" ]
 

--- a/ckcc/constants.py
+++ b/ckcc/constants.py
@@ -7,6 +7,22 @@ try:
 except ImportError:
     const = int
 
+# USB encryption versions (default USB_NCRY_V1)
+#
+# This introduces a new ncry version to close a potential attack vector:
+#
+# A malicious program may re-initialize the connection encryption by sending the ncry command a second time during USB operation.
+# This may prove particularly harmful in HSM mode.
+#
+# Sending version USB_NCRY_V2 changes the behavior in two ways:
+#   * All future commands must be encrypted
+#   * Returns an error if the ncry command is sent again for the duration of the power cycle
+#
+# USB_NCRY_V2 is most suitable for HSM mode as in case of any communication issue or simply by closing `ColdcardDevice`
+# Coldcard will need to reboot to recover USB operation if USB_NCRY_V2.
+USB_NCRY_V1 = const(0x01)
+USB_NCRY_V2 = const(0x02)
+
 # For upload/download this is the max size of the data block.
 MAX_BLK_LEN = const(2048)
 

--- a/ckcc/protocol.py
+++ b/ckcc/protocol.py
@@ -68,7 +68,11 @@ class CCProtocolPacker:
         return b'back'
 
     @staticmethod
-    def encrypt_start(device_pubkey, version=0x1):
+    def encrypt_start(device_pubkey, version=USB_NCRY_V1):
+        supported_versions = [USB_NCRY_V1, USB_NCRY_V2]
+        if version not in supported_versions:
+            raise ValueError("Unsupported USB encryption version. "
+                             "Supported versions: %s" % (supported_versions))
         assert len(device_pubkey) == 64, "want uncompressed 64-byte pubkey, no prefix byte"
         return pack('<4sI64s', b'ncry', version, device_pubkey)
 

--- a/tests/test_usb_ncry.py
+++ b/tests/test_usb_ncry.py
@@ -1,0 +1,71 @@
+import pytest
+from ckcc.constants import AF_P2WPKH, USB_NCRY_V1, USB_NCRY_V2
+from ckcc.client import ColdcardDevice, CCProtocolPacker
+
+
+# v2 tests require you to have firmware supporting usb encryption v2
+# after each v2 test, coldcard needs to be reconnected
+
+
+def test_ncry_v1():
+    # USB_NCRY_V1 is the default
+    dev = ColdcardDevice()
+    session_key = dev.session_key
+    assert session_key
+    # re-establish shared secret
+    dev.start_encryption()
+    assert dev.ncry_ver == USB_NCRY_V1
+    assert session_key != dev.session_key
+    session_key = dev.session_key
+    # we can do this many times over - it will always work
+    dev.start_encryption()
+    assert dev.ncry_ver == USB_NCRY_V1
+    assert session_key != dev.session_key
+
+
+def test_ncry_v2():
+    # after this test, one needs to reconnect coldcard
+    dev = ColdcardDevice(ncry_ver=USB_NCRY_V2)
+    assert dev.session_key
+    assert dev.ncry_ver == USB_NCRY_V2
+    # cannot start new session - already bound
+    with pytest.raises(Exception):
+        dev.start_encryption()
+    # cannot start new session even with v2 - already bound
+    with pytest.raises(Exception):
+        dev.start_encryption(version=USB_NCRY_V2)
+    # if above conditions are met - all commands gonna be encrypted
+    assert dev.ncry_ver == USB_NCRY_V2
+    addr = dev.send_recv(CCProtocolPacker.show_address("m/84'/0'/0'/0/0", AF_P2WPKH), timeout=None)
+    assert addr
+
+
+def test_ncry_v2_via_start_encryption():
+    dev = ColdcardDevice()
+    assert dev.session_key
+    assert dev.ncry_ver == USB_NCRY_V1
+    dev.start_encryption(version=USB_NCRY_V2)
+    assert dev.ncry_ver == USB_NCRY_V2
+    # cannot start new session - already bound
+    with pytest.raises(Exception):
+        dev.start_encryption()
+    # cannot start new session even with v2 - already bound
+    with pytest.raises(Exception):
+        dev.start_encryption(version=USB_NCRY_V2)
+    # test some commands
+    assert dev.ncry_ver == USB_NCRY_V2
+    assert dev.encrypt_request is not None
+    # if above conditions are met - all commands gonna be encrypted
+    addr = dev.send_recv(CCProtocolPacker.show_address("m/84'/0'/0'/0/0", AF_P2WPKH), timeout=None)
+    assert addr
+
+
+def test_unsupported_version():
+    dev = ColdcardDevice()
+    with pytest.raises(ValueError):
+        dev.start_encryption(version=0x3)
+    dev.close()
+    with pytest.raises(ValueError):
+        ColdcardDevice(ncry_ver=0x3)
+
+


### PR DESCRIPTION
two ways to set v2 usb encryption:
1. directly set `ncry_ver` on new `ColdcardDevice` object
2. with already created client/device, use `ColdcardDevice.start_encryption(version=USB_NCRY_V2)`