### PR TITLE
add `MAX_SIGNERS` as constant to constants.py

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -24,7 +24,7 @@ from ecdsa import VerifyingKey, SECP256k1
 
 from ckcc.protocol import CCProtocolPacker, CCProtocolUnpacker
 from ckcc.protocol import CCProtoError, CCUserRefused, CCBusyError
-from ckcc.constants import MAX_MSG_LEN, MAX_BLK_LEN, MAX_USERNAME_LEN
+from ckcc.constants import MAX_MSG_LEN, MAX_BLK_LEN, MAX_USERNAME_LEN, MAX_SIGNERS
 from ckcc.constants import USER_AUTH_HMAC, USER_AUTH_TOTP, USER_AUTH_HOTP, USER_AUTH_SHOW_QR
 from ckcc.constants import AF_CLASSIC, AF_P2SH, AF_P2WPKH, AF_P2WSH, AF_P2WPKH_P2SH, AF_P2WSH_P2SH
 from ckcc.constants import STXN_FINALIZE, STXN_VISUALIZE, STXN_SIGNED
@@ -660,7 +660,7 @@ def show_address(script, fingerprints, quiet=False, segwit=False, wrap=False):
         script = a2b_hex(script)
         N = len(fingerprints)
 
-        assert 1 <= N <= 15, "bad N"
+        assert 1 <= N <= MAX_SIGNERS, "bad N"
 
         min_signers = script[0] - 80
         assert 1 <= min_signers <= N, "bad M"

--- a/ckcc/constants.py
+++ b/ckcc/constants.py
@@ -43,6 +43,11 @@ MAX_UPLOAD_LEN_MK4 = const(2*MAX_TXN_LEN_MK4)
 # Max length of text messages for signing
 MSG_SIGNING_MAX_LENGTH = const(240)
 
+# Bitcoin limitation: max number of signatures in P2SH redeem script (non-segwit)
+# - 520 byte redeem script limit <= 15*34 bytes per pubkey == 510 bytes
+# - serializations of M/N in redeem scripts assume this range
+MAX_SIGNERS = const(15)
+
 # Types of user auth we support
 USER_AUTH_TOTP = const(1)       # RFC6238
 USER_AUTH_HOTP = const(2)       # RFC4226


### PR DESCRIPTION
* better to have this value in `constants.py` than in `shared/multisig.py` in firmware (as it is a constant)