### PR TITLE
proper metavars

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -875,7 +875,7 @@ def miniscript_ls():
 
 @miniscript.command('del')
 @click.argument('name', type=str,
-                metavar="Miniscript wallet name",
+                metavar="MINISCRIPT_WALLET_NAME",
                 required=True)
 def miniscript_del(name):
     """
@@ -890,7 +890,7 @@ def miniscript_del(name):
 
 @miniscript.command('get')
 @click.argument('name', type=str,
-                metavar="Miniscript wallet name",
+                metavar="MINISCRIPT_WALLET_NAME",
                 required=True)
 def miniscript_get(name):
     """
@@ -907,11 +907,11 @@ def miniscript_get(name):
 
 @miniscript.command('addr')
 @click.argument('name', type=str,
-                metavar="Miniscript wallet name",
+                metavar="MINISCRIPT_WALLET_NAME",
                 required=True)
 @click.argument('index',
                 type=click.IntRange(min=0, max=(2**31)-1),
-                metavar="Address index", required=True)
+                metavar="ADDR_IDX", required=True)
 @click.option('--change', is_flag=True, default=False,
               help='Use internal chain.')
 def miniscript_address(name, change, index):


### PR DESCRIPTION
As ARGUMENTs are only show in `Usage:` line in click default help. This is more readable imo.

before:
```
$ ckcc miniscript addr --help 
Usage: ckcc miniscript addr [OPTIONS] Miniscript wallet name Address index

  Get miniscript internal/external chain address by index with on device
  verification.

Options:
  --change  Use internal chain.
  --help    Show this message and exit.
```

after:
```
Usage: ckcc miniscript addr [OPTIONS] MINISCRIPT_WALLET_NAME ADDR_IDX

  Get miniscript internal/external chain address by index with on device
  verification.

Options:
  --change  Use internal chain.
  --help    Show this message and exit.
```