### PR TITLE
DRAFT: fix?

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -241,7 +241,7 @@ def real_file_upload(fd, dev, blksize=MAX_BLK_LEN, do_upgrade=False, do_reboot=T
             if not here: break
             left -= len(here)
             result = dev.send_recv(CCProtocolPacker.upload(pos, sz, here))
-            assert result == pos, "Got back: %r" % result
+            assert result == pos, f"Got back: {result}"
             chk.update(here)
 
     # do a verify


### PR DESCRIPTION
```
❯ ckcc upgrade 2025-02-13T1415-v5.4.1-mk4-coldcard.dfu
946176 bytes (start @ 293) to send from '2025-02-13T1415-v5.4.1-mk4-coldcard.dfu'
Uploading  [#####-------------------------------]   15%  00:02:06
Traceback (most recent call last):
  File "/usr/bin/ckcc", line 33, in <module>
    sys.exit(load_entry_point('ckcc-protocol==1.4.0', 'console_scripts', 'ckcc')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/ckcc/cli.py", line 308, in firmware_upgrade
    real_file_upload(filename, dev, do_upgrade=True, do_reboot=(not stop_early))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/ckcc/cli.py", line 244, in real_file_upload
    assert result == pos, "Got back: %r" % result
                          ~~~~~~~~~~~~~~~^~~~~~~~
TypeError: not all arguments converted during string formatting
```

I cannot repro above (yet), but error is clear and result is in that case holding more than one value - above should at least correctly assert raise with result properly formatted to error string