### PR TITLE
bugfix: exception exporting multisig skeleton

### DIFF
--- a/ckcc/cli.py
+++ b/ckcc/cli.py
@@ -735,18 +735,26 @@ def bip39_passphrase(passphrase, verbose=False):
 
 
 @main.command('multisig')
-@click.option('--min-signers', '-m', type=int, help='Minimum M signers of N required to approve (default: all)', default=0)
-@click.option('--signers', '-n', 'num_signers', type=int, help='N signers in wallet', default=3)
-@click.option('--name', '-l', type=str, help='Wallet name on Coldcard', default='Unnamed')
+@click.option('--min-signers', '-m', type=int, default=0,
+              help='Minimum M signers of N required to approve (default: all)')
+@click.option('--signers', '-n', 'num_signers', type=int, default=3,
+              help='N signers in wallet')
+@click.option('--name', '-l', type=str, default='Unnamed',
+              help='Wallet name on Coldcard')
 @click.option('--output-file', '-f', type=click.File('wt', lazy=True),
-                                help='Save configuration to file')
-@click.option('--verbose', '-v', is_flag=True, help='Show file uploaded')
-@click.option('--path', '-p', default="m/45'", help="Derivation for key (default: BIP45 = m/45')")
-@click.option('--add', '-a', 'just_add', is_flag=True, help='Just show line required to add this Coldcard')
-@click.option('--desc', '-d', 'descriptor', is_flag=True, help='Use BIP380 descriptor template')
-@click.option('--format', type=click.Choice(["p2sh", "p2sh-p2wsh", "p2wsh"]), help='Address format')
-def enroll_xpub(name, min_signers, path,  num_signers, output_file=None, verbose=False, just_add=False,
-                descriptor=False, format="p2wsh"):
+              help='Save configuration to file')
+@click.option('--verbose', '-v', is_flag=True,
+              help='Show file uploaded')
+@click.option('--path', '-p', default="m/45'",
+              help="Derivation for key (default: BIP45 = m/45')")
+@click.option('--add', '-a', 'just_add', is_flag=True,
+              help='Just show line required to add this Coldcard')
+@click.option('--desc', '-d', 'descriptor', is_flag=True,
+              help='Use BIP380 descriptor template')
+@click.option('--format', type=click.Choice(["p2sh", "p2sh-p2wsh", "p2wsh"]),
+              help='Address format', default="p2wsh")
+def enroll_xpub(name, min_signers, path,  num_signers, output_file, verbose,
+                just_add, descriptor, format):
     """
     Create a skeleton file which defines a multisig wallet.
     When completed, use with: "ckcc upload -m wallet.txt" or put on SD card.


### PR DESCRIPTION
running `ckcc multisg` causes

```
$ ckcc -x multisig 
Traceback (most recent call last):
  File "ckcc-protocol/ENV/bin/ckcc", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ckcc-protocol/ENV/lib/python3.12/site-packages/ckcc/cli.py", line 796, in enroll_xpub
    config = f'name: {name}\npolicy: {min_signers} of {N}\nformat: {format.upper()}\n\n#path: {path}\n{new_line}\n'
                                                                    ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
```

default argument needs to be specified in option/argument decorator - not in function signature. Function args/kwargs get overwritten by decorated function

fixed by moving default `p2wsh` format option to click decorator